### PR TITLE
Make reading speed and minimum page length configurable

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Reading Time",
-  "version": "1.6",
+  "version": "1.7",
 
   "description": "Displays the estimated reading time for a website in a small popup element.",
   "homepage_url": "https://github.com/scripts-richard/reading_time",
@@ -25,5 +25,19 @@
       "css": ["./reading_time.css"],
       "run_at": "document_end"
     }
-  ]
+  ],
+
+  "permissions": [
+    "storage"
+  ],
+
+  "options_ui": {
+    "page": "options.html"
+  },
+
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{ec628514-4772-4476-8ce6-3787fc5d29da}"
+    }
+  }
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,11 @@
+<form>
+    <label for="reading_speed">Reading speed (words per minute): </label>
+    <input ID="reading_speed" type="number" />
+
+    <br />
+
+    <label for="popup_when_minutes_over">Show popup when page is longer than (minutes): </label>
+    <input ID="popup_when_minutes_over" type="number" />
+</form>
+
+<script src="options.js"></script>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,27 @@
+async function load_options() {
+    await load_option("reading_speed", 200);
+    await load_option("popup_when_minutes_over", 0);
+}
+
+async function load_option(setting_name, default_value)
+{
+    const option = await browser.storage.sync.get(setting_name);
+
+    const ui_control = document.querySelector(`#${setting_name}`);
+    ui_control.value = option[setting_name] || default_value;
+}
+
+async function save_option(setting_name)
+{
+    const ui_control = document.querySelector(`#${setting_name}`);
+
+    const option = {};
+    option[setting_name] = ui_control.value;
+
+    await browser.storage.sync.set(option);
+}
+
+
+document.addEventListener("DOMContentLoaded", load_options);
+document.querySelectorAll("input")
+    .forEach(i => i.addEventListener("change", async e => await save_option(e.currentTarget.id)));

--- a/reading_time.js
+++ b/reading_time.js
@@ -1,6 +1,3 @@
-// Estimated reading speed of 200 words per minute.
-const READING_SPEED = 200;
-
 const DEBUG = false;
 
 
@@ -66,23 +63,44 @@ function count_words_by_element_name(element_name) {
 }
 
 
-// Count all words in body of document
-let word_count = count_words(document.body.innerText);
-DEBUG && console.log("Body word count:", word_count);
+const settings = browser.storage.sync;
+Promise.all([
+    settings.get("reading_speed"),
+    settings.get("popup_when_minutes_over")
+  ])
+  .then(r => {
+    const reading_speed = r[0]?.reading_speed || 200;
+    const popup_when_minutes_over = r[1]?.popup_when_minutes_over || 0;
 
-// Less all words in navigation elements
-word_count -= count_words_by_element_name("nav");
+    show_reading_time(reading_speed, popup_when_minutes_over);
+  });
 
-// Less all words in header elements
-word_count -= count_words_by_element_name("header");
 
-// Less all words in footer elements
-word_count -= count_words_by_element_name("footer");
-DEBUG && console.log("Word count:", word_count);
+function show_reading_time(reading_speed, popup_when_minutes_over) {
 
-// Estimated reading time
-let reading_time = Math.round(word_count / READING_SPEED);
-DEBUG && console.log("Reading time:", reading_time);
+  DEBUG && console.log("reading_speed", reading_speed);
+  DEBUG && console.log("popup_when_minutes_over", popup_when_minutes_over);
 
-// Spawn reading time element
-create_element(reading_time);
+  // Count all words in body of document
+  let word_count = count_words(document.body.innerText);
+  DEBUG && console.log("Body word count:", word_count);
+
+  // Less all words in navigation elements
+  word_count -= count_words_by_element_name("nav");
+
+  // Less all words in header elements
+  word_count -= count_words_by_element_name("header");
+
+  // Less all words in footer elements
+  word_count -= count_words_by_element_name("footer");
+  DEBUG && console.log("Word count:", word_count);
+
+  // Estimated reading time
+  let reading_time = Math.round(word_count / reading_speed);
+  DEBUG && console.log("Reading time:", reading_time);
+
+  // Spawn reading time element
+  if (reading_time >= popup_when_minutes_over) {
+    create_element(reading_time);
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Reading Time
 
-A simple Firefox extension that adds a pop-up to web-pages with the estimated reading time, based on 200 words per minute.
+A simple Firefox extension that adds a pop-up to web-pages with the estimated reading time, based on 200 words per minute (configurable in the addon options).
 
 <p>
   <img src="./reading-time-sample.png" alt="Reading Time screen shot">

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -19,3 +19,5 @@ v1.5
 v1.6
 - New element design.
 - Design features to normalize element across different websites.
+v1.7
+- Added options to customise WPM and when the popup appears.


### PR DESCRIPTION
Hey, thanks for the great add-on.

I made a couple of enhancements if you are interested in them:
* The reading speed is configurable in the add-on options (defaults to 200 WPM)
* Added an option to only show the popup on larger pages