### PR TITLE
Hide reading time element when printing

### DIFF
--- a/reading_time.css
+++ b/reading_time.css
@@ -29,3 +29,9 @@
   content: "X";
   font-weight: bold;
 }
+
+@media print {
+  .reading_time_element {
+    display: none;
+  }
+}


### PR DESCRIPTION
I noticed that the reading time element is still visible when printing a page via `Ctl-P`, so I've added some CSS that uses the `@media print` media query to hide the element when printing.